### PR TITLE
Additional Modification: added codes which clear content of on-disk pages corresponding to HashTableHeaderPage at hash index reconstuction

### DIFF
--- a/storage/index/index_test/hash_table_index_test.go
+++ b/storage/index/index_test/hash_table_index_test.go
@@ -159,7 +159,7 @@ func TestRecounstructionOfHashIndex(t *testing.T) {
 
 	// reconstruct all index data of all column
 	tableMetadata = c.GetTableByName("test_1")
-	samehada.ReconstructAllIndexData(c, txn)
+	samehada.ReconstructAllIndexData(c, dman, txn)
 	shi.GetTransactionManager().Commit(txn)
 
 	// checking reconstruction result of index data by getting tuples using index


### PR DESCRIPTION
- added codes which clear content of on-disk pages corresponding to HashTableHeaderPage at hash index reconstuction for avoiding confliction
  - there may be pages(on disk) which has old index entries data in current design...